### PR TITLE
Skip pypy3.8

### DIFF
--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -14,6 +14,9 @@ for PYBIN in /opt/python/*/bin; do
     if [ $("${PYBIN}/python" --version 2>&1 | grep -c "Python ${PYTHON}") -eq 0 ]; then
         continue
     fi
+    if [[ "${PYBIN}" == *"pypy3.8"* ]]; then
+        continue
+    fi
 
     # Setup
     TMP_DIR="${SOURCE_DIR}/wheelhouse_tmp/${PLAT}/${PYBIN}"


### PR DESCRIPTION
Building wheels for pypy 3.8 throws an error, which leads to all py3.8 builds not being uploaded. I propose we skip it, at least for now.

```
Building wheels for collected packages: s-gd2
  Building wheel for s-gd2 (setup.py): started
  Building wheel for s-gd2 (setup.py): finished with status 'error'
  error: subprocess-exited-with-error
  
  × python setup.py bdist_wheel did not run successfully.
  │ exit code: 1
  ╰─> [37 lines of output]
      /opt/_internal/pypy3.8-7.3.7/lib/pypy3.8/site-packages/setuptools/installer.py:30: SetuptoolsDeprecationWarning: setuptools.installer is deprecated. Requirements should be satisfied by a PEP 517 installer.
        SetuptoolsDeprecationWarning,
      running bdist_wheel
      running build
      running build_py
      creating build/lib.linux-x86_64-pypy38
      creating build/lib.linux-x86_64-pypy38/s_gd2
      copying s_gd2/s_gd2.py -> build/lib.linux-x86_64-pypy38/s_gd2
      copying s_gd2/version.py -> build/lib.linux-x86_64-pypy38/s_gd2
      copying s_gd2/__init__.py -> build/lib.linux-x86_64-pypy38/s_gd2
      creating build/lib.linux-x86_64-pypy38/s_gd2/swig
      copying s_gd2/swig/layout.py -> build/lib.linux-x86_64-pypy38/s_gd2/swig
      copying s_gd2/swig/__init__.py -> build/lib.linux-x86_64-pypy38/s_gd2/swig
      running build_ext
      building '_layout' extension
      /opt/_internal/pypy3.8-7.3.7/lib/pypy3.8/site-packages/numpy/core/_add_newdocs.py:2922: UserWarning: add_newdoc was used on a pure-python object <bound method __class_getitem__ of <class 'numpy.ndarray'>>. Prefer to attach it directly to the source.
        add_newdoc('numpy.core.multiarray', 'ndarray', ('__class_getitem__',
      /opt/_internal/pypy3.8-7.3.7/lib/pypy3.8/site-packages/numpy/core/_add_newdocs.py:6243: UserWarning: add_newdoc was used on a pure-python object <bound method __class_getitem__ of <class 'numpy.dtype'>>. Prefer to attach it directly to the source.
        add_newdoc('numpy.core.multiarray', 'dtype', ('__class_getitem__',
      /opt/_internal/pypy3.8-7.3.7/lib/pypy3.8/site-packages/numpy/core/_add_newdocs.py:6755: UserWarning: add_newdoc was used on a pure-python object <bound method __class_getitem__ of <class 'numpy.number'>>. Prefer to attach it directly to the source.
        add_newdoc('numpy.core.numerictypes', 'number', ('__class_getitem__',
      creating build/temp.linux-x86_64-pypy38
      creating build/temp.linux-x86_64-pypy38/s_gd2
      creating build/temp.linux-x86_64-pypy38/s_gd2/swig
      gcc -pthread -DNDEBUG -O2 -fPIC -I/opt/_internal/pypy3.8-7.3.7/lib/pypy3.8/site-packages/numpy/core/include -I./s_gd2/ -I/opt/_internal/pypy3.8-7.3.7/include/pypy3.8 -c ./s_gd2/layout.cpp -o build/temp.linux-x86_64-pypy38/./s_gd2/layout.o
      gcc -pthread -DNDEBUG -O2 -fPIC -I/opt/_internal/pypy3.8-7.3.7/lib/pypy3.8/site-packages/numpy/core/include -I./s_gd2/ -I/opt/_internal/pypy3.8-7.3.7/include/pypy3.8 -c ./s_gd2/randomkit.c -o build/temp.linux-x86_64-pypy38/./s_gd2/randomkit.o
      gcc -pthread -DNDEBUG -O2 -fPIC -I/opt/_internal/pypy3.8-7.3.7/lib/pypy3.8/site-packages/numpy/core/include -I./s_gd2/ -I/opt/_internal/pypy3.8-7.3.7/include/pypy3.8 -c ./s_gd2/sparse.cpp -o build/temp.linux-x86_64-pypy38/./s_gd2/sparse.o
      gcc -pthread -DNDEBUG -O2 -fPIC -I/opt/_internal/pypy3.8-7.3.7/lib/pypy3.8/site-packages/numpy/core/include -I./s_gd2/ -I/opt/_internal/pypy3.8-7.3.7/include/pypy3.8 -c ./s_gd2/swig/layout_wrap.cxx -o build/temp.linux-x86_64-pypy38/./s_gd2/swig/layout_wrap.o
      ./s_gd2/swig/layout_wrap.cxx: In function ‘PyTypeObject* SwigPyPacked_TypeOnce()’:
      ./s_gd2/swig/layout_wrap.cxx:2129:7: error: invalid conversion from ‘printfunc’ {aka ‘int (*)(_object*, _IO_FILE*, int)’} to ‘Py_ssize_t’ {aka ‘long int’} [-fpermissive]
             (printfunc)SwigPyPacked_print,        /* tp_print */
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      ./s_gd2/swig/layout_wrap.cxx: In function ‘PyTypeObject* swig_varlink_type()’:
      ./s_gd2/swig/layout_wrap.cxx:5328:9: error: invalid conversion from ‘printfunc’ {aka ‘int (*)(_object*, _IO_FILE*, int)’} to ‘Py_ssize_t’ {aka ‘long int’} [-fpermissive]
               (printfunc) swig_varlink_print,     /* tp_print */
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      error: command '/opt/rh/devtoolset-8/root/usr/bin/gcc' failed with exit code 1
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for s-gd2
  Running setup.py clean for s-gd2
Failed to build s-gd2
ERROR: Failed to build one or more wheels
```